### PR TITLE
Use freeuio() to free allocated uio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "scripts/zfs-images"]
-	path = scripts/zfs-images
-	url = https://github.com/openzfs/zfs-images

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6580,7 +6580,7 @@ print_holds(boolean_t scripted, int nwidth, int tagwidth, nvlist_t *nvl,
 			if (scripted) {
 				if (parsable) {
 					(void) printf("%s\t%s\t%ld\n", zname,
-					    tagname, time);
+					    tagname, (unsigned long)time);
 				} else {
 					(void) printf("%s\t%s\t%s\n", zname,
 					    tagname, tsbuf);
@@ -6589,7 +6589,7 @@ print_holds(boolean_t scripted, int nwidth, int tagwidth, nvlist_t *nvl,
 				if (parsable) {
 					(void) printf("%-*s  %-*s  %ld\n",
 					    nwidth, zname, tagwidth,
-					    tagname, time);
+					    tagname, (unsigned long)time);
 				} else {
 					(void) printf("%-*s  %-*s  %s\n",
 					    nwidth, zname, tagwidth,

--- a/include/os/freebsd/spl/sys/simd_aarch64.h
+++ b/include/os/freebsd/spl/sys/simd_aarch64.h
@@ -50,8 +50,15 @@
 #include <machine/md_var.h>
 #include <machine/pcb.h>
 
+#ifdef _STANDALONE
+
+#define	kfpu_allowed()		0
+#define	kfpu_begin()		do {} while (0)
+#define	kfpu_end()		do {} while (0)
+
+#else
+
 #define	kfpu_allowed()		1
-#define	kfpu_initialize(tsk)	do {} while (0)
 #define	kfpu_begin() do {						\
 	if (__predict_false(!is_fpu_kern_thread(0)))			\
 		fpu_kern_enter(curthread, NULL, FPU_KERN_NOCTX);	\
@@ -61,6 +68,10 @@
 	if (__predict_false(curthread->td_pcb->pcb_fpflags & PCB_FP_NOSAVE)) \
 		fpu_kern_leave(curthread, NULL);			\
 } while (0)
+
+#endif
+
+#define	kfpu_initialize(tsk)	do {} while (0)
 #define	kfpu_init()		(0)
 #define	kfpu_fini()		do {} while (0)
 

--- a/include/os/freebsd/spl/sys/simd_arm.h
+++ b/include/os/freebsd/spl/sys/simd_arm.h
@@ -46,7 +46,7 @@
 #include <machine/elf.h>
 #include <machine/md_var.h>
 
-#define	kfpu_allowed()		1
+#define	kfpu_allowed()		0
 #define	kfpu_initialize(tsk)	do {} while (0)
 #define	kfpu_begin()		do {} while (0)
 #define	kfpu_end()		do {} while (0)

--- a/module/icp/algs/blake3/blake3_impl.c
+++ b/module/icp/algs/blake3/blake3_impl.c
@@ -30,10 +30,13 @@
 
 #include "blake3_impl.h"
 
-#if defined(__aarch64__) || \
+#if !defined(OMIT_SIMD) && (defined(__aarch64__) ||  \
 	(defined(__x86_64) && defined(HAVE_SSE2)) || \
-	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
+    (defined(__PPC64__) && defined(__LITTLE_ENDIAN__)))
+#define USE_SIMD
+#endif
 
+#ifdef USE_SIMD
 extern void ASMABI zfs_blake3_compress_in_place_sse2(uint32_t cv[8],
     const uint8_t block[BLAKE3_BLOCK_LEN], uint8_t block_len,
     uint64_t counter, uint8_t flags);
@@ -96,9 +99,7 @@ const blake3_ops_t blake3_sse2_impl = {
 };
 #endif
 
-#if defined(__aarch64__) || \
-	(defined(__x86_64) && defined(HAVE_SSE2)) || \
-	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
+#ifdef USE_SIMD
 
 extern void ASMABI zfs_blake3_compress_in_place_sse41(uint32_t cv[8],
     const uint8_t block[BLAKE3_BLOCK_LEN], uint8_t block_len,
@@ -257,6 +258,7 @@ extern const blake3_ops_t blake3_generic_impl;
 
 static const blake3_ops_t *const blake3_impls[] = {
 	&blake3_generic_impl,
+#ifdef USE_SIMD
 #if defined(__aarch64__) || \
 	(defined(__x86_64) && defined(HAVE_SSE2)) || \
 	(defined(__PPC64__) && defined(__LITTLE_ENDIAN__))
@@ -272,6 +274,7 @@ static const blake3_ops_t *const blake3_impls[] = {
 #endif
 #if defined(__x86_64) && defined(HAVE_AVX512F) && defined(HAVE_AVX512VL)
 	&blake3_avx512_impl,
+#endif
 #endif
 };
 

--- a/module/os/freebsd/spl/spl_taskq.c
+++ b/module/os/freebsd/spl/spl_taskq.c
@@ -200,7 +200,7 @@ taskq_tsd_set(void *context)
 {
 	taskq_t *tq = context;
 
-#if defined(__amd64__) || defined(__i386__) || defined(__aarch64__)
+#if defined(__amd64__) || defined(__aarch64__) 
 	if (context != NULL && tsd_get(taskq_tsd) == NULL)
 		fpu_kern_thread(FPU_KERN_NORMAL);
 #endif

--- a/module/os/freebsd/spl/spl_uio.c
+++ b/module/os/freebsd/spl/spl_uio.c
@@ -45,6 +45,15 @@
 #include <sys/vnode.h>
 #include <sys/zfs_znode.h>
 
+/* XXX: should be an __FreeBSD_version check once API is upstream. */
+#ifndef UIO_EXT_IOVEC
+void
+freeuio(struct uio *uio)
+{
+	free(uio, M_IOV);
+}
+#endif
+
 int
 zfs_uiomove(void *cp, size_t n, zfs_uio_rw_t dir, zfs_uio_t *uio)
 {
@@ -77,7 +86,7 @@ zfs_uiocopy(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio, size_t *cbytes)
 	error = vn_io_fault_uiomove(p, n, uio_clone);
 	*cbytes = zfs_uio_resid(uio) - uio_clone->uio_resid;
 	if (uio_clone != &small_uio_clone)
-		free(uio_clone, M_IOV);
+		freeuio(uio_clone);
 	return (error);
 }
 

--- a/module/os/freebsd/zfs/zfs_vnops_os.c
+++ b/module/os/freebsd/zfs/zfs_vnops_os.c
@@ -6324,9 +6324,7 @@ bad_locked_fallback:
 bad_write_fallback:
 	if (mp != NULL)
 		vn_finished_write(mp);
-	error = vn_generic_copy_file_range(ap->a_invp, ap->a_inoffp,
-	    ap->a_outvp, ap->a_outoffp, ap->a_lenp, ap->a_flags,
-	    ap->a_incred, ap->a_outcred, ap->a_fsizetd);
+	error = ENOSYS;
 	return (error);
 }
 #endif

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -50,9 +50,11 @@
 #include "lib/zstd.h"
 #include "lib/common/zstd_errors.h"
 
+#ifndef IN_LIBSA
 static uint_t zstd_earlyabort_pass = 1;
 static int zstd_cutoff_level = ZIO_ZSTD_LEVEL_3;
 static unsigned int zstd_abort_size = (128 * 1024);
+#endif
 
 static kstat_t *zstd_ksp = NULL;
 
@@ -180,16 +182,20 @@ struct zstd_levelmap {
  *
  * The ZSTD handlers were split up for the most simplified implementation.
  */
+#ifndef IN_LIBSA
 static void *zstd_alloc(void *opaque, size_t size);
+#endif
 static void *zstd_dctx_alloc(void *opaque, size_t size);
 static void zstd_free(void *opaque, void *ptr);
 
+#ifndef IN_LIBSA
 /* Compression memory handler */
 static const ZSTD_customMem zstd_malloc = {
 	zstd_alloc,
 	zstd_free,
 	NULL,
 };
+#endif
 
 /* Decompression memory handler */
 static const ZSTD_customMem zstd_dctx_malloc = {
@@ -429,7 +435,7 @@ zstd_enum_to_level(enum zio_zstd_levels level, int16_t *zstd_level)
 	return (1);
 }
 
-
+#ifndef IN_LIBSA
 size_t
 zfs_zstd_compress_wrap(void *s_start, void *d_start, size_t s_len, size_t d_len,
     int level)
@@ -593,6 +599,7 @@ zfs_zstd_compress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 
 	return (c_len + sizeof (*hdr));
 }
+#endif
 
 /* Decompress block using zstd and return its stored level */
 int
@@ -680,6 +687,7 @@ zfs_zstd_decompress(void *s_start, void *d_start, size_t s_len, size_t d_len,
 	    NULL));
 }
 
+#ifndef IN_LIBSA
 /* Allocator for zstd compression context using mempool_allocator */
 static void *
 zstd_alloc(void *opaque __maybe_unused, size_t size)
@@ -696,6 +704,7 @@ zstd_alloc(void *opaque __maybe_unused, size_t size)
 
 	return ((void*)z + (sizeof (struct zstd_kmem)));
 }
+#endif
 
 /*
  * Allocator for zstd decompression context using mempool_allocator with

--- a/module/zstd/zfs_zstd.c
+++ b/module/zstd/zfs_zstd.c
@@ -844,6 +844,13 @@ zstd_mempool_deinit(void)
 void
 zfs_zstd_cache_reap_now(void)
 {
+
+	/*
+	 * Short-circuit if there are no buffers to begin with.
+	 */
+	if (ZSTDSTAT(zstd_stat_buffers) == 0)
+		return;
+
 	/*
 	 * calling alloc with zero size seeks
 	 * and releases old unused objects


### PR DESCRIPTION
Actually belongs at the bottom of `cheri-purecap`, but making a pull request against `freebsd` for review purposes.